### PR TITLE
Add std types for Rocket (and uuid)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ transient-derive = { path = "derive", version = "0.3", optional = true }
 ndarray = { version = "0.15", optional = true }
 numpy = { version = "0.21", optional = true }
 pyo3 = { version = ">=0.21", optional = true }
+uuid = { version = "1", optional = true }
 
 [dev-dependencies]
 trybuild = { version = "1.0.49", features = ["diff"] }
@@ -42,6 +43,7 @@ pyo3 = ["dep:pyo3"]
 
 # Provides `Transient` implementations for `numpy` types
 numpy = ["dep:numpy", "ndarray", "pyo3"]
+uuid = ["dep:uuid"]
 
 [workspace.lints.clippy]
 let_unit_value = "warn"

--- a/src/transient.rs
+++ b/src/transient.rs
@@ -340,7 +340,7 @@ pub unsafe trait Transient: Sized {
 /// Implementing this trait results in a `Transient` implementation using `Self`
 /// as the `Static` type and `()` as the `Transience`, which is almost certainly
 /// what a `'static` type would want.
-pub trait Static: 'static {}
+pub trait Static: 'static + Sized {}
 
 unsafe impl<S: Static> Transient for S {
     type Static = Self;
@@ -448,7 +448,6 @@ mod std_impls {
         type Transience = Co<'a>;
     }
     impl_refs!(&'a str ['a]);
-    impl Static for str {}
 
     unsafe impl<'a, T: Transient> Transient for &'a [T] {
         type Static = &'static [T::Static];

--- a/src/transient.rs
+++ b/src/transient.rs
@@ -370,7 +370,12 @@ mod std_impls {
 
     use std::any::Any as StdAny;
     use std::borrow::{Cow, ToOwned};
+    use std::char::ParseCharError;
     use std::collections::HashMap;
+    use std::net::AddrParseError;
+    use std::num::{ParseFloatError, ParseIntError};
+    use std::str::ParseBoolError;
+    use std::string::ParseError;
 
     macro_rules! impl_refs {
         {
@@ -431,7 +436,10 @@ mod std_impls {
     impl_primatives! {
         isize, i8, i16, i32, i64, i128,
         usize, u8, u16, u32, u64, u128,
-        f32, f64, String, Box<str>, ()
+        f32, f64, String, Box<str>, (),
+        ParseIntError, ParseCharError,
+        ParseFloatError, ParseBoolError,
+        ParseError, AddrParseError,
     }
 
     unsafe impl<'a> Transient for &'a str {
@@ -439,6 +447,7 @@ mod std_impls {
         type Transience = Co<'a>;
     }
     impl_refs!(&'a str ['a]);
+    impl Static for str {}
 
     unsafe impl<'a, T: Transient> Transient for &'a [T] {
         type Static = &'static [T::Static];
@@ -595,4 +604,14 @@ mod numpy_impls {
         type Static = PyReadwriteArray<'static, T, D>;
         type Transience = crate::Co<'py>;
     }
+}
+
+#[cfg(feature = "uuid")]
+mod uuid_impls {
+    use super::Static;
+    use uuid::*;
+    impl Static for Uuid {}
+    impl Static for Error {}
+    impl Static for Variant {}
+    impl Static for Version {}
 }

--- a/src/transient.rs
+++ b/src/transient.rs
@@ -424,7 +424,7 @@ mod std_impls {
         }
     }
 
-    macro_rules! impl_primatives {
+    macro_rules! impl_static {
         ( $($ty:ty),* $(,)? ) => {
             $(
             impl Static for $ty {}
@@ -433,13 +433,14 @@ mod std_impls {
         }
     }
 
-    impl_primatives! {
+    impl_static! {
         isize, i8, i16, i32, i64, i128,
         usize, u8, u16, u32, u64, u128,
         f32, f64, String, Box<str>, (),
         ParseIntError, ParseCharError,
         ParseFloatError, ParseBoolError,
         ParseError, AddrParseError,
+        std::io::Error,
     }
 
     unsafe impl<'a> Transient for &'a str {


### PR DESCRIPTION
Adds `Static` implementations for a number of std error types, and adds an optional dependency on `uuid`, with appropriate `Static` impls.