### PR TITLE
Updates to stdlib `Transient` impls and added `Transience` bound to `Transience` associated types.

### DIFF
--- a/src/transience.rs
+++ b/src/transience.rs
@@ -142,9 +142,9 @@ pub unsafe trait Transience:
     Transient + CanTranscendTo<Self> + CanRecoverFrom<Self>
 {
     /// The inverse of this transience. `Co` <=> `Contra`, and `Inv` <=> `Inv`.
-    type Inverse;
+    type Inverse: Transience;
     /// The invariant version of this transience. `Co`, `Contra` => `Inv`.
-    type Invariant;
+    type Invariant: Transience;
 }
 
 /// Unsafe marker trait indicating that the implementing [`Transience`] can

--- a/src/transient.rs
+++ b/src/transient.rs
@@ -366,7 +366,7 @@ const fn check_static_type<T: Transient>() {
 
 mod std_impls {
     use super::{Static, Transient};
-    use crate::{Co, Inv, Covariant, Invariant};
+    use crate::{Co, Covariant, Inv, Invariant};
 
     use std::any::Any as StdAny;
     use std::borrow::{Cow, ToOwned};


### PR DESCRIPTION
The `Transience::Inverse` and `Transience::Invariant` associated types need to have `Transience` bounds in order for them to be used in the `Transience` of other types without extra `where` clauses.

I also noticed that some of the `Transient` impls for stdlib types were not properly accounting for the variance of their associated types, so I fixed those. I used the new `Covariant<T>`, etc. mechanism introduced in PR #8 to fix this, and updated the other impls to use this mechanism as well.

Finally, I added new impls for several types such as `Cell<T>`, `*const T`, and `*mut T`.