### PR TITLE
Bumped version to 0.4.0.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "transient"
-version = "0.3.0"
+version = "0.4.0"
 description = "Reimplementation of `std::any::Any` with support for non-`'static` types"
 authors = ["Joshua Rudolph <jrrudolph93@gmail.com>"]
 readme = "README.md"
@@ -20,7 +20,7 @@ doctest = true
 members = ["derive"]
 
 [dependencies]
-transient-derive = { path = "derive", version = "0.3", optional = true }
+transient-derive = { path = "derive", version = "0.4", optional = true }
 ndarray = { version = "0.15", optional = true }
 numpy = { version = "0.21", optional = true }
 pyo3 = { version = ">=0.21", optional = true }

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "transient-derive"
-version = "0.3.0"
+version = "0.4.0"
 description = "Proc macro for deriving the `transient::Transient` trait"
 authors = ["Joshua Rudolph <jrrudolph93@gmail.com>"]
 keywords = ["any", "static", "downcast", "typeid"]


### PR DESCRIPTION
This PR marks the release of `transient` v0.4.0.

This new version includes significant updates to the derive macro (#3, #4) that adds support for arbitrary number of lifetimes and completely safe variance selection by generating validation functions.

Also included is work towards more robust support for non-`'static` generic type parameters (#8, #10), which will be further integrated with the derive macro (#5) in the next release.

Finally, this update includes a number of new `Transient` impls for stdlib types and those in the `uuid` library (behind the `uuid` feature flag), as well as improvements and fixes to the existing impls (#7, #10).

Big thanks to @the10thWiz for his numerous contributions!