### PR TITLE
Added "crate" option to the `Transient` derive macro

### DIFF
--- a/derive/src/checks.rs
+++ b/derive/src/checks.rs
@@ -16,7 +16,7 @@ pub(super) struct ChecksModule<'a> {
 impl<'a> ChecksModule<'a> {
     #[rustfmt::skip]
     pub(super) fn new(impl_: &'a TransientImpl<'a>) -> Option<Self> {
-        let TransientImpl(self_type, _, transience) = impl_;
+        let TransientImpl(self_type, _, transience, _) = impl_;
         let name = Ident::new(
             &format!("__validate_{}", self_type.name),
             self_type.name.span(),

--- a/derive/src/options.rs
+++ b/derive/src/options.rs
@@ -1,0 +1,58 @@
+use syn::parse::{Parse, ParseStream};
+use syn::punctuated::Punctuated;
+use syn::{Path, Token};
+
+use crate::{Error, Result};
+
+enum TransientOption {
+    Crate(Path),
+}
+
+impl Parse for TransientOption {
+    fn parse(input: ParseStream<'_>) -> syn::Result<Self> {
+        let lookahead = input.lookahead1();
+        if lookahead.peek(Token![crate]) {
+            let _: Token![crate] = input.parse()?;
+            let _: Token![=] = input.parse()?;
+            input.parse().map(Self::Crate)
+        } else {
+            Err(Error::InvalidOption(input.span()).into())
+        }
+    }
+}
+
+pub(crate) struct TransientOptions {
+    pub(crate) krate: syn::Path,
+}
+
+impl TransientOptions {
+    fn set(&mut self, opt: TransientOption) {
+        match opt {
+            TransientOption::Crate(path) => {
+                self.krate = path;
+            }
+        }
+    }
+}
+
+impl Default for TransientOptions {
+    fn default() -> Self {
+        TransientOptions { krate: syn::parse_quote! { ::transient } }
+    }
+}
+
+impl TransientOptions {
+    pub(crate) fn extract(attrs: &[syn::Attribute]) -> Result<Self> {
+        let mut options = Self::default();
+        let parser = Punctuated::<TransientOption, syn::Token![,]>::parse_terminated;
+        for attr in attrs
+            .iter()
+            .filter(|attr| attr.path().is_ident("transient"))
+        {
+            for option in attr.parse_args_with(parser)? {
+                options.set(option)
+            }
+        }
+        Ok(options)
+    }
+}

--- a/derive/tests/expand/05-alternate-crate.expanded.rs
+++ b/derive/tests/expand/05-alternate-crate.expanded.rs
@@ -1,0 +1,37 @@
+//! Verifies that the mixed variance attributes expands as expected
+use transient_derive::Transient;
+#[transient(crate = mycrate::transient)]
+#[contravariant(a)]
+#[covariant(b)]
+struct ContraCo<'a, 'b, T> {
+    value1: fn(&'a T) -> &'b str,
+}
+unsafe impl<'a, 'b, T> mycrate::transient::Transient for ContraCo<'a, 'b, T>
+where
+    T: 'static,
+{
+    type Static = ContraCo<'static, 'static, T>;
+    type Transience = (mycrate::transient::Contra<'a>, mycrate::transient::Co<'b>);
+}
+mod __validate_ContraCo {
+    #![allow(non_snake_case, dead_code)]
+    use super::*;
+    fn contravariant_wrt_a<'__short, 'a, 'b, T>(
+        v: ContraCo<'__short, 'b, T>,
+    ) -> ContraCo<'a, 'b, T>
+    where
+        T: 'static,
+        'a: '__short,
+    {
+        v
+    }
+    fn covariant_wrt_b<'__long, 'a, 'b, T>(
+        v: ContraCo<'a, '__long, T>,
+    ) -> ContraCo<'a, 'b, T>
+    where
+        T: 'static,
+        '__long: 'b,
+    {
+        v
+    }
+}

--- a/derive/tests/expand/05-alternate-crate.rs
+++ b/derive/tests/expand/05-alternate-crate.rs
@@ -1,0 +1,10 @@
+//! Verifies that the mixed variance attributes expands as expected
+use transient_derive::Transient;
+
+#[derive(Transient)]
+#[transient(crate = mycrate::transient)]
+#[contravariant(a)]
+#[covariant(b)]
+struct ContraCo<'a, 'b, T> {
+    value1: fn(&'a T) -> &'b str,
+}

--- a/derive/tests/pass/07-alternate-crate.rs
+++ b/derive/tests/pass/07-alternate-crate.rs
@@ -1,0 +1,16 @@
+//! Verifies that the mixed variance attributes expands as expected
+use transient_derive::Transient;
+
+mod mycrate {
+    pub use transient;
+}
+
+#[derive(Transient)]
+#[transient(crate = mycrate::transient)]
+#[contravariant(a)]
+#[covariant(b)]
+struct ContraCo<'a, 'b, T> {
+    value1: fn(&'a T) -> &'b str,
+}
+
+fn main() {}


### PR DESCRIPTION
This PR implements a mechanism for specifying an alternate root path for the derive macro to use when referencing symbols in the `transient` crate.

This can be useful when a downstream library wants to re-export `Transient` macro without requiring its users to add an explicit dependency on the `transient` crate.