### PR TITLE
MSRV bump to 1.60, MSRV compliance fix, and CI updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
+          args: --all-features
 
       - name: Lint
         uses: actions-rs/cargo@v1
@@ -48,6 +49,28 @@ jobs:
         with:
           command: fmt
           args: --all -- --check
+
+  build-msrv:
+    name: Build MSRV
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: "1.61"
+          override: true
+
+      - name: Build
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --all --all-features
+        env:
+          CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
 
   test-derive:
     name: Test Derive Macro

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,8 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: "1.61"
+          # 1.68 used instead of the true MSRV to avoid long CI runs
+          toolchain: "1.68"
           override: true
 
       - name: Build

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,8 @@ doctest = true
 members = ["derive"]
 
 [dependencies]
+rustversion = "1.0"
+
 transient-derive = { path = "derive", version = "0.4", optional = true }
 ndarray = { version = "0.15", optional = true }
 numpy = { version = "0.21", optional = true }
@@ -28,7 +30,7 @@ uuid = { version = "1", optional = true }
 either = { version = ">=1", default-features = false, optional = true }
 
 [dev-dependencies]
-trybuild = { version = "1.0.49", features = ["diff"] }
+trybuild = { version = "1.0", features = ["diff"] }
 
 [features]
 default = ["derive"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ documentation = "https://docs.rs/transient"
 license = "MIT OR Apache-2.0"
 exclude = ["/.gitignore"]
 edition = "2021"
-rust-version = "1.56"
+rust-version = "1.60"
 
 [lib]
 doctest = true

--- a/src/any.rs
+++ b/src/any.rs
@@ -5,11 +5,15 @@ use crate::{
     transience::{CanRecoverFrom, CanTranscendTo, Transience},
     transient::Transient,
 };
+use std::marker::{Send, Sync};
 
 /// Re-export from the [`std::any`] module.
-///
+#[rustversion::before(1.76)]
+pub use std::any::type_name;
+
+/// Re-export from the [`std::any`] module.
+#[rustversion::since(1.76)]
 pub use std::any::{type_name, type_name_of_val};
-use std::marker::{Send, Sync};
 
 ///////////////////////////////////////////////////////////////////////////////
 // `Any` trait

--- a/src/transient.rs
+++ b/src/transient.rs
@@ -431,7 +431,7 @@ mod std_impls {
         core::num::ParseFloatError,
         core::num::ParseIntError,
         core::str::ParseBoolError,
-        core::net::AddrParseError,
+        std::net::AddrParseError,
         std::io::Error,
     }
 


### PR DESCRIPTION
Despite the MSRV has being set to 1.56, the crate re-exports `std::any::type_name_of_val` which wasn't stabilized until rustc 1.76. This PR adds a conditional compilation gate to this re-export to properly compile on v1.56. This requires adding a compile-time-only dependency on the `rustversion` crate, which should be lightweight enough to be harmless.

However, another issue is that the "dep:" syntax in Cargo.toml was not stabilized until rustc 1.60. Working around this would be annoying due to feature/dependency name conflicts, so instead this PR includes an MSRV bump to 1.60 which should still be old enough for the vast majority of crates to support.

Finally, the CI has been updated to build the crate with a rustc version below the `type_name_of_val` cutoff, which would ideally be the MSRV. However, updating the crates.io registry is crazy slow for versions below 1.68 when the sparse protocol was implemented, so this version will be used in the CI instead. Note that the CI will not run tests for this version due to higher MSRV for the `try-build` dev dependency, but building the crate should be good enough to catch MSRV violations. 