### PR TITLE
Scope generated checks in a way that prevents them from being named

### DIFF
--- a/derive/src/checks.rs
+++ b/derive/src/checks.rs
@@ -18,7 +18,7 @@ impl<'a> ChecksModule<'a> {
     pub(super) fn new(impl_: &'a TransientImpl<'a>) -> Option<Self> {
         let TransientImpl(self_type, _, transience, _) = impl_;
         let name = Ident::new(
-            &format!("__validate_{}", self_type.name),
+            &format!("validate_{}", self_type.name),
             self_type.name.span(),
         );
         let funcs = transience.0.iter()
@@ -36,11 +36,13 @@ impl<'a> ToTokens for ChecksModule<'a> {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         let ChecksModule { name, funcs } = self;
         tokens.extend(quote!(
-            mod #name {
-                #![allow(non_snake_case, dead_code)]
-                use super::*;
-                #(#funcs)*
-            }
+            const _: () = {
+                mod #name {
+                    #![allow(non_snake_case, dead_code)]
+                    use super::*;
+                    #(#funcs)*
+                }
+            };
         ));
     }
 }

--- a/derive/tests/expand/02-covariance.expanded.rs
+++ b/derive/tests/expand/02-covariance.expanded.rs
@@ -19,16 +19,18 @@ unsafe impl<'a> ::transient::Transient for LifetimeOnly<'a> {
     type Static = LifetimeOnly<'static>;
     type Transience = ::transient::Co<'a>;
 }
-mod __validate_LifetimeOnly {
-    #![allow(non_snake_case, dead_code)]
-    use super::*;
-    fn covariant_wrt_a<'__long, 'a>(v: LifetimeOnly<'__long>) -> LifetimeOnly<'a>
-    where
-        '__long: 'a,
-    {
-        v
+const _: () = {
+    mod validate_LifetimeOnly {
+        #![allow(non_snake_case, dead_code)]
+        use super::*;
+        fn covariant_wrt_a<'__long, 'a>(v: LifetimeOnly<'__long>) -> LifetimeOnly<'a>
+        where
+            '__long: 'a,
+        {
+            v
+        }
     }
-}
+};
 #[covariant(a)]
 struct TypeAndLifetime<'a, T> {
     value: &'a T,
@@ -40,19 +42,21 @@ where
     type Static = TypeAndLifetime<'static, T>;
     type Transience = ::transient::Co<'a>;
 }
-mod __validate_TypeAndLifetime {
-    #![allow(non_snake_case, dead_code)]
-    use super::*;
-    fn covariant_wrt_a<'__long, 'a, T>(
-        v: TypeAndLifetime<'__long, T>,
-    ) -> TypeAndLifetime<'a, T>
-    where
-        T: 'static,
-        '__long: 'a,
-    {
-        v
+const _: () = {
+    mod validate_TypeAndLifetime {
+        #![allow(non_snake_case, dead_code)]
+        use super::*;
+        fn covariant_wrt_a<'__long, 'a, T>(
+            v: TypeAndLifetime<'__long, T>,
+        ) -> TypeAndLifetime<'a, T>
+        where
+            T: 'static,
+            '__long: 'a,
+        {
+            v
+        }
     }
-}
+};
 #[covariant(a)]
 struct TypesAndLifetime<'a, T1, T2> {
     value1: &'a T1,
@@ -66,20 +70,22 @@ where
     type Static = TypesAndLifetime<'static, T1, T2>;
     type Transience = ::transient::Co<'a>;
 }
-mod __validate_TypesAndLifetime {
-    #![allow(non_snake_case, dead_code)]
-    use super::*;
-    fn covariant_wrt_a<'__long, 'a, T1, T2>(
-        v: TypesAndLifetime<'__long, T1, T2>,
-    ) -> TypesAndLifetime<'a, T1, T2>
-    where
-        T1: 'static,
-        T2: 'static,
-        '__long: 'a,
-    {
-        v
+const _: () = {
+    mod validate_TypesAndLifetime {
+        #![allow(non_snake_case, dead_code)]
+        use super::*;
+        fn covariant_wrt_a<'__long, 'a, T1, T2>(
+            v: TypesAndLifetime<'__long, T1, T2>,
+        ) -> TypesAndLifetime<'a, T1, T2>
+        where
+            T1: 'static,
+            T2: 'static,
+            '__long: 'a,
+        {
+            v
+        }
     }
-}
+};
 #[covariant(a, b)]
 struct TypesAndTwoLifetimes<'a, 'b, T1, T2: 'static> {
     value1: &'a T1,
@@ -93,25 +99,27 @@ where
     type Static = TypesAndTwoLifetimes<'static, 'static, T1, T2>;
     type Transience = (::transient::Co<'a>, ::transient::Co<'b>);
 }
-mod __validate_TypesAndTwoLifetimes {
-    #![allow(non_snake_case, dead_code)]
-    use super::*;
-    fn covariant_wrt_a<'__long, 'a, 'b, T1, T2: 'static>(
-        v: TypesAndTwoLifetimes<'__long, 'b, T1, T2>,
-    ) -> TypesAndTwoLifetimes<'a, 'b, T1, T2>
-    where
-        T1: 'static,
-        '__long: 'a,
-    {
-        v
+const _: () = {
+    mod validate_TypesAndTwoLifetimes {
+        #![allow(non_snake_case, dead_code)]
+        use super::*;
+        fn covariant_wrt_a<'__long, 'a, 'b, T1, T2: 'static>(
+            v: TypesAndTwoLifetimes<'__long, 'b, T1, T2>,
+        ) -> TypesAndTwoLifetimes<'a, 'b, T1, T2>
+        where
+            T1: 'static,
+            '__long: 'a,
+        {
+            v
+        }
+        fn covariant_wrt_b<'__long, 'a, 'b, T1, T2: 'static>(
+            v: TypesAndTwoLifetimes<'a, '__long, T1, T2>,
+        ) -> TypesAndTwoLifetimes<'a, 'b, T1, T2>
+        where
+            T1: 'static,
+            '__long: 'b,
+        {
+            v
+        }
     }
-    fn covariant_wrt_b<'__long, 'a, 'b, T1, T2: 'static>(
-        v: TypesAndTwoLifetimes<'a, '__long, T1, T2>,
-    ) -> TypesAndTwoLifetimes<'a, 'b, T1, T2>
-    where
-        T1: 'static,
-        '__long: 'b,
-    {
-        v
-    }
-}
+};

--- a/derive/tests/expand/03-contravariance.expanded.rs
+++ b/derive/tests/expand/03-contravariance.expanded.rs
@@ -8,16 +8,20 @@ unsafe impl<'a> ::transient::Transient for LifetimeOnly<'a> {
     type Static = LifetimeOnly<'static>;
     type Transience = ::transient::Contra<'a>;
 }
-mod __validate_LifetimeOnly {
-    #![allow(non_snake_case, dead_code)]
-    use super::*;
-    fn contravariant_wrt_a<'__short, 'a>(v: LifetimeOnly<'__short>) -> LifetimeOnly<'a>
-    where
-        'a: '__short,
-    {
-        v
+const _: () = {
+    mod validate_LifetimeOnly {
+        #![allow(non_snake_case, dead_code)]
+        use super::*;
+        fn contravariant_wrt_a<'__short, 'a>(
+            v: LifetimeOnly<'__short>,
+        ) -> LifetimeOnly<'a>
+        where
+            'a: '__short,
+        {
+            v
+        }
     }
-}
+};
 #[contravariant(a)]
 struct TypeAndLifetime<'a, T> {
     value: fn(&'a T),
@@ -29,19 +33,21 @@ where
     type Static = TypeAndLifetime<'static, T>;
     type Transience = ::transient::Contra<'a>;
 }
-mod __validate_TypeAndLifetime {
-    #![allow(non_snake_case, dead_code)]
-    use super::*;
-    fn contravariant_wrt_a<'__short, 'a, T>(
-        v: TypeAndLifetime<'__short, T>,
-    ) -> TypeAndLifetime<'a, T>
-    where
-        T: 'static,
-        'a: '__short,
-    {
-        v
+const _: () = {
+    mod validate_TypeAndLifetime {
+        #![allow(non_snake_case, dead_code)]
+        use super::*;
+        fn contravariant_wrt_a<'__short, 'a, T>(
+            v: TypeAndLifetime<'__short, T>,
+        ) -> TypeAndLifetime<'a, T>
+        where
+            T: 'static,
+            'a: '__short,
+        {
+            v
+        }
     }
-}
+};
 #[contravariant(a)]
 struct TypesAndLifetime<'a, T1, T2> {
     value1: fn(&'a T1) -> T2,
@@ -54,20 +60,22 @@ where
     type Static = TypesAndLifetime<'static, T1, T2>;
     type Transience = ::transient::Contra<'a>;
 }
-mod __validate_TypesAndLifetime {
-    #![allow(non_snake_case, dead_code)]
-    use super::*;
-    fn contravariant_wrt_a<'__short, 'a, T1, T2>(
-        v: TypesAndLifetime<'__short, T1, T2>,
-    ) -> TypesAndLifetime<'a, T1, T2>
-    where
-        T1: 'static,
-        T2: 'static,
-        'a: '__short,
-    {
-        v
+const _: () = {
+    mod validate_TypesAndLifetime {
+        #![allow(non_snake_case, dead_code)]
+        use super::*;
+        fn contravariant_wrt_a<'__short, 'a, T1, T2>(
+            v: TypesAndLifetime<'__short, T1, T2>,
+        ) -> TypesAndLifetime<'a, T1, T2>
+        where
+            T1: 'static,
+            T2: 'static,
+            'a: '__short,
+        {
+            v
+        }
     }
-}
+};
 #[contravariant(a, b)]
 struct TypesAndTwoLifetimes<'a, 'b, T1, T2> {
     value1: fn(&'a T1),
@@ -82,27 +90,29 @@ where
     type Static = TypesAndTwoLifetimes<'static, 'static, T1, T2>;
     type Transience = (::transient::Contra<'a>, ::transient::Contra<'b>);
 }
-mod __validate_TypesAndTwoLifetimes {
-    #![allow(non_snake_case, dead_code)]
-    use super::*;
-    fn contravariant_wrt_a<'__short, 'a, 'b, T1, T2>(
-        v: TypesAndTwoLifetimes<'__short, 'b, T1, T2>,
-    ) -> TypesAndTwoLifetimes<'a, 'b, T1, T2>
-    where
-        T1: 'static,
-        T2: 'static,
-        'a: '__short,
-    {
-        v
+const _: () = {
+    mod validate_TypesAndTwoLifetimes {
+        #![allow(non_snake_case, dead_code)]
+        use super::*;
+        fn contravariant_wrt_a<'__short, 'a, 'b, T1, T2>(
+            v: TypesAndTwoLifetimes<'__short, 'b, T1, T2>,
+        ) -> TypesAndTwoLifetimes<'a, 'b, T1, T2>
+        where
+            T1: 'static,
+            T2: 'static,
+            'a: '__short,
+        {
+            v
+        }
+        fn contravariant_wrt_b<'__short, 'a, 'b, T1, T2>(
+            v: TypesAndTwoLifetimes<'a, '__short, T1, T2>,
+        ) -> TypesAndTwoLifetimes<'a, 'b, T1, T2>
+        where
+            T1: 'static,
+            T2: 'static,
+            'b: '__short,
+        {
+            v
+        }
     }
-    fn contravariant_wrt_b<'__short, 'a, 'b, T1, T2>(
-        v: TypesAndTwoLifetimes<'a, '__short, T1, T2>,
-    ) -> TypesAndTwoLifetimes<'a, 'b, T1, T2>
-    where
-        T1: 'static,
-        T2: 'static,
-        'b: '__short,
-    {
-        v
-    }
-}
+};

--- a/derive/tests/expand/04-mixed-variance.expanded.rs
+++ b/derive/tests/expand/04-mixed-variance.expanded.rs
@@ -12,28 +12,30 @@ where
     type Static = ContraCo<'static, 'static, T>;
     type Transience = (::transient::Contra<'a>, ::transient::Co<'b>);
 }
-mod __validate_ContraCo {
-    #![allow(non_snake_case, dead_code)]
-    use super::*;
-    fn contravariant_wrt_a<'__short, 'a, 'b, T>(
-        v: ContraCo<'__short, 'b, T>,
-    ) -> ContraCo<'a, 'b, T>
-    where
-        T: 'static,
-        'a: '__short,
-    {
-        v
+const _: () = {
+    mod validate_ContraCo {
+        #![allow(non_snake_case, dead_code)]
+        use super::*;
+        fn contravariant_wrt_a<'__short, 'a, 'b, T>(
+            v: ContraCo<'__short, 'b, T>,
+        ) -> ContraCo<'a, 'b, T>
+        where
+            T: 'static,
+            'a: '__short,
+        {
+            v
+        }
+        fn covariant_wrt_b<'__long, 'a, 'b, T>(
+            v: ContraCo<'a, '__long, T>,
+        ) -> ContraCo<'a, 'b, T>
+        where
+            T: 'static,
+            '__long: 'b,
+        {
+            v
+        }
     }
-    fn covariant_wrt_b<'__long, 'a, 'b, T>(
-        v: ContraCo<'a, '__long, T>,
-    ) -> ContraCo<'a, 'b, T>
-    where
-        T: 'static,
-        '__long: 'b,
-    {
-        v
-    }
-}
+};
 #[covariant(a)]
 struct CoInv<'a, 'b, T1, T2> {
     value1: &'a T1,
@@ -47,20 +49,22 @@ where
     type Static = CoInv<'static, 'static, T1, T2>;
     type Transience = (::transient::Co<'a>, ::transient::Inv<'b>);
 }
-mod __validate_CoInv {
-    #![allow(non_snake_case, dead_code)]
-    use super::*;
-    fn covariant_wrt_a<'__long, 'a, 'b, T1, T2>(
-        v: CoInv<'__long, 'b, T1, T2>,
-    ) -> CoInv<'a, 'b, T1, T2>
-    where
-        T1: 'static,
-        T2: 'static,
-        '__long: 'a,
-    {
-        v
+const _: () = {
+    mod validate_CoInv {
+        #![allow(non_snake_case, dead_code)]
+        use super::*;
+        fn covariant_wrt_a<'__long, 'a, 'b, T1, T2>(
+            v: CoInv<'__long, 'b, T1, T2>,
+        ) -> CoInv<'a, 'b, T1, T2>
+        where
+            T1: 'static,
+            T2: 'static,
+            '__long: 'a,
+        {
+            v
+        }
     }
-}
+};
 #[covariant]
 struct GlobalCo<'a, 'b, T1, T2> {
     value1: &'a T1,
@@ -74,27 +78,29 @@ where
     type Static = GlobalCo<'static, 'static, T1, T2>;
     type Transience = (::transient::Co<'a>, ::transient::Co<'b>);
 }
-mod __validate_GlobalCo {
-    #![allow(non_snake_case, dead_code)]
-    use super::*;
-    fn covariant_wrt_a<'__long, 'a, 'b, T1, T2>(
-        v: GlobalCo<'__long, 'b, T1, T2>,
-    ) -> GlobalCo<'a, 'b, T1, T2>
-    where
-        T1: 'static,
-        T2: 'static,
-        '__long: 'a,
-    {
-        v
+const _: () = {
+    mod validate_GlobalCo {
+        #![allow(non_snake_case, dead_code)]
+        use super::*;
+        fn covariant_wrt_a<'__long, 'a, 'b, T1, T2>(
+            v: GlobalCo<'__long, 'b, T1, T2>,
+        ) -> GlobalCo<'a, 'b, T1, T2>
+        where
+            T1: 'static,
+            T2: 'static,
+            '__long: 'a,
+        {
+            v
+        }
+        fn covariant_wrt_b<'__long, 'a, 'b, T1, T2>(
+            v: GlobalCo<'a, '__long, T1, T2>,
+        ) -> GlobalCo<'a, 'b, T1, T2>
+        where
+            T1: 'static,
+            T2: 'static,
+            '__long: 'b,
+        {
+            v
+        }
     }
-    fn covariant_wrt_b<'__long, 'a, 'b, T1, T2>(
-        v: GlobalCo<'a, '__long, T1, T2>,
-    ) -> GlobalCo<'a, 'b, T1, T2>
-    where
-        T1: 'static,
-        T2: 'static,
-        '__long: 'b,
-    {
-        v
-    }
-}
+};

--- a/derive/tests/expand/05-alternate-crate.expanded.rs
+++ b/derive/tests/expand/05-alternate-crate.expanded.rs
@@ -13,25 +13,27 @@ where
     type Static = ContraCo<'static, 'static, T>;
     type Transience = (mycrate::transient::Contra<'a>, mycrate::transient::Co<'b>);
 }
-mod __validate_ContraCo {
-    #![allow(non_snake_case, dead_code)]
-    use super::*;
-    fn contravariant_wrt_a<'__short, 'a, 'b, T>(
-        v: ContraCo<'__short, 'b, T>,
-    ) -> ContraCo<'a, 'b, T>
-    where
-        T: 'static,
-        'a: '__short,
-    {
-        v
+const _: () = {
+    mod validate_ContraCo {
+        #![allow(non_snake_case, dead_code)]
+        use super::*;
+        fn contravariant_wrt_a<'__short, 'a, 'b, T>(
+            v: ContraCo<'__short, 'b, T>,
+        ) -> ContraCo<'a, 'b, T>
+        where
+            T: 'static,
+            'a: '__short,
+        {
+            v
+        }
+        fn covariant_wrt_b<'__long, 'a, 'b, T>(
+            v: ContraCo<'a, '__long, T>,
+        ) -> ContraCo<'a, 'b, T>
+        where
+            T: 'static,
+            '__long: 'b,
+        {
+            v
+        }
     }
-    fn covariant_wrt_b<'__long, 'a, 'b, T>(
-        v: ContraCo<'a, '__long, T>,
-    ) -> ContraCo<'a, 'b, T>
-    where
-        T: 'static,
-        '__long: 'b,
-    {
-        v
-    }
-}
+};


### PR DESCRIPTION
I found out that you can scope items inside a constant's declaration block, which makes it impossible to refer to them outside of the block. I adjusted codegen to output checks like this:

```rust
const _: () = {
    /* checks */
};
```

Since it's impossible to refer to anything in the constant's declaration block, it cannot possibly conflict with anything the user wishes to declare. I also took a moment to change the module name to be easier to read.