### PR TITLE
Add built-in support for bools

### DIFF
--- a/src/transient.rs
+++ b/src/transient.rs
@@ -425,7 +425,7 @@ mod std_impls {
     impl_static! {
         isize, i8, i16, i32, i64, i128,
         usize, u8, u16, u32, u64, u128,
-        f32, f64, String, Box<str>, (),
+        f32, f64, String, Box<str>, (), bool,
         std::char::ParseCharError,
         std::char::DecodeUtf16Error,
         std::convert::Infallible,


### PR DESCRIPTION
Thanks for this project. It really helped me for a thing I'm working on.

I just noticed a gap in the supported rust std types and thought I'd add it for you.