### PR TITLE
Add docstring to test module

### DIFF
--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,3 +1,5 @@
+//! Tests for various parts of the Transient API
+
 /// Tests for a covariant struct with no generic type parameters.
 mod covariant {
     use crate::{tr::Transient, Any, Co, Downcast, TypeId};


### PR DESCRIPTION
Rust nightly now requires #[cfg(test)] items to have docstrings when `#[deny(missing_docs)]` is used. This PR adds a simple docstring to satisfy this requirement.
