### PR TITLE
Added test case filters to avoid `compile_fail` tests that fail due to trivial output changes.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,7 @@ rmp-serde = ["dep:rmp-serde"]
 let_unit_value = "warn"
 manual_assert = "warn"
 unnecessary_wraps = "warn"
+needless-lifetimes = "allow"
 
 [workspace.lints.rust]
 elided_lifetimes_in_paths = "warn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,6 @@ rmp-serde = ["dep:rmp-serde"]
 let_unit_value = "warn"
 manual_assert = "warn"
 unnecessary_wraps = "warn"
-needless-lifetimes = "allow"
 
 [workspace.lints.rust]
 elided_lifetimes_in_paths = "warn"

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -27,4 +27,5 @@ thiserror = "1"
 [dev-dependencies]
 trybuild = { version = "1.0.96", features = ["diff"] }
 macrotest = "1.0.12"
+rustversion = "1.0"
 transient = { path = ".." }

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -1,7 +1,7 @@
 //! Defines the [`Transient`][crate::Transient] derive macro that safely implements
 //! the [`Transient`][transient::tr::Transient] trait for any struct with at most 4
 //! lifetime parameters.
-#![allow(unknown_lints, clippy::needless_lifetimes)] 
+#![allow(unknown_lints, clippy::needless_lifetimes)]
 use proc_macro::TokenStream;
 use proc_macro2::{Span, TokenStream as TokenStream2};
 use quote::{quote, ToTokens};

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -1,6 +1,7 @@
 //! Defines the [`Transient`][crate::Transient] derive macro that safely implements
 //! the [`Transient`][transient::tr::Transient] trait for any struct with at most 4
 //! lifetime parameters.
+#![allow(unknown_lints, clippy::needless_lifetimes)] 
 use proc_macro::TokenStream;
 use proc_macro2::{Span, TokenStream as TokenStream2};
 use quote::{quote, ToTokens};

--- a/derive/tests/test_derive.rs
+++ b/derive/tests/test_derive.rs
@@ -3,8 +3,8 @@ fn test_pass() {
     let t = trybuild::TestCases::new();
     t.pass("tests/pass/*.rs");
 }
-
-#[rustversion::stable]
+// #[rustversion::stable]
+#[rustversion::all(since(1.82), stable)]
 #[test]
 fn test_fail() {
     let t = trybuild::TestCases::new();

--- a/derive/tests/test_derive.rs
+++ b/derive/tests/test_derive.rs
@@ -4,6 +4,7 @@ fn test_pass() {
     t.pass("tests/pass/*.rs");
 }
 
+#[rustversion::stable]
 #[test]
 fn test_fail() {
     let t = trybuild::TestCases::new();

--- a/derive/tests/test_derive.rs
+++ b/derive/tests/test_derive.rs
@@ -3,7 +3,7 @@ fn test_pass() {
     let t = trybuild::TestCases::new();
     t.pass("tests/pass/*.rs");
 }
-// #[rustversion::stable]
+
 #[rustversion::all(since(1.82), stable)]
 #[test]
 fn test_fail() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -308,7 +308,7 @@
 //! [_subtyping and variance_]: https://doc.rust-lang.org/nomicon/subtyping.html
 //! [*the quality or state of being transient*]: https://www.merriam-webster.com/dictionary/transience
 #![deny(missing_docs, clippy::missing_safety_doc)]
-#![allow(unknown_lints, clippy::too_long_first_doc_paragraph)]
+#![allow(unknown_lints, clippy::too_long_first_doc_paragraph, clippy::needless_lifetimes)]
 
 pub mod any;
 pub mod transience;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -308,7 +308,11 @@
 //! [_subtyping and variance_]: https://doc.rust-lang.org/nomicon/subtyping.html
 //! [*the quality or state of being transient*]: https://www.merriam-webster.com/dictionary/transience
 #![deny(missing_docs, clippy::missing_safety_doc)]
-#![allow(unknown_lints, clippy::too_long_first_doc_paragraph, clippy::needless_lifetimes)]
+#![allow(
+    unknown_lints,
+    clippy::too_long_first_doc_paragraph,
+    clippy::needless_lifetimes
+)]
 
 pub mod any;
 pub mod transience;

--- a/tests/fail/mixed-contravariance-misuse.stderr
+++ b/tests/fail/mixed-contravariance-misuse.stderr
@@ -7,6 +7,6 @@ error: lifetime may not live long enough
    |                lifetime `'short` defined here
 ...
 16 |     long_long
-   |     ^^^^^^^^^ cast requires that `'short` must outlive `'long`
+   |     ^^^^^^^^^ coercion requires that `'short` must outlive `'long`
    |
    = help: consider adding the following bound: `'short: 'long`

--- a/tests/test_compiler_error.rs
+++ b/tests/test_compiler_error.rs
@@ -1,6 +1,5 @@
 //! Entry-point for tests that should fail to compile with an expected error message
 
-// #[rustversion::stable]
 #[rustversion::all(since(1.82), stable)]
 #[test]
 #[cfg_attr(miri, ignore)]

--- a/tests/test_compiler_error.rs
+++ b/tests/test_compiler_error.rs
@@ -1,6 +1,7 @@
 //! Entry-point for tests that should fail to compile with an expected error message
 
-#[rustversion::stable]
+// #[rustversion::stable]
+#[rustversion::all(since(1.82), stable)]
 #[test]
 #[cfg_attr(miri, ignore)]
 fn variance_tests() {

--- a/tests/test_compiler_error.rs
+++ b/tests/test_compiler_error.rs
@@ -1,5 +1,6 @@
 //! Entry-point for tests that should fail to compile with an expected error message
 
+#[rustversion::stable]
 #[test]
 #[cfg_attr(miri, ignore)]
 fn variance_tests() {


### PR DESCRIPTION
As pointed out by @the10thWiz, trivial changes to the output messages on certain rustc versions cause the `compile_fail` tests to fail (particularly in the CI workflow). This PR updates the expected outputs to match that of the latest stable Rust version, and adds `rustversion` attributes that skip these tests on older rustc versions (as well as the nightly/beta channels).