### PR TITLE
Implemented `no_std` support (with/without `alloc`)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,11 @@ jobs:
           - stable
           - beta
           - nightly
+        features:
+          - --no-default-features
+          - --no-default-features --features alloc
+          - --features default
+          - --all-features
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
@@ -30,13 +35,13 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --all --all-features
+          args: --all ${{ matrix.features }}
 
       - name: Test
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --all-features
+          args: ${{ matrix.features }}
 
       - name: Lint
         uses: actions-rs/cargo@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
           - nightly
         features:
           - --no-default-features
-          - --no-default-features --features alloc
+          - --features alloc --no-default-features
           - --features default
           - --all-features
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --all ${{ matrix.features }}
+          args: ${{ matrix.features }}
 
       - name: Test
         uses: actions-rs/cargo@v1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,16 @@ rmp-serde = { version = ">=1", default-features = false, optional = true }
 trybuild = { version = "1.0", features = ["diff"] }
 
 [features]
-default = ["derive"]
+default = ["std", "derive"]
+
+# Provide impls for common standard library types like Vec<T> and HashMap<K, V>.
+# Requires a dependency on the Rust standard library.
+std = []
+
+# Provide impls for types in the Rust core allocation and collections library
+# including String, Box<T>, Vec<T>, and Cow<T>. This is a subset of std but may
+# be enabled without depending on all of std.
+alloc = []
 
 # Provides a `derive` macro for implementing the `Transient` trait
 derive = ["transient-derive"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ std = ["alloc"]
 alloc = []
 
 # Provides a `derive` macro for implementing the `Transient` trait
-derive = ["std", "transient-derive"]
+derive = ["transient-derive"]
 
 # Provides `Transient` implementations for `ndarray` types
 ndarray = ["dep:ndarray"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ std = []
 alloc = []
 
 # Provides a `derive` macro for implementing the `Transient` trait
-derive = ["transient-derive"]
+derive = ["std", "transient-derive"]
 
 # Provides `Transient` implementations for `ndarray` types
 ndarray = ["dep:ndarray"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ default = ["std", "derive"]
 
 # Provide impls for common standard library types like Vec<T> and HashMap<K, V>.
 # Requires a dependency on the Rust standard library.
-std = []
+std = ["alloc"]
 
 # Provide impls for types in the Rust core allocation and collections library
 # including String, Box<T>, Vec<T>, and Cow<T>. This is a subset of std but may

--- a/src/any.rs
+++ b/src/any.rs
@@ -346,6 +346,8 @@ impl TypeId {
     /// # Examples
     ///
     /// ```
+    /// 
+    /// # #[cfg(any(feature = "std", feature = "alloc"))] {
     /// use transient::{Transient, Any, TypeId};
     ///
     /// fn is_string_slice<T: Transient>(_s: &T) -> bool {
@@ -359,6 +361,7 @@ impl TypeId {
     /// assert_eq!(is_string_slice(&string), false);
     /// assert_eq!(is_string_slice(&string_slice), true);
     /// assert_eq!(is_string_slice(&"cookie monster"), true);
+    /// # }
     /// ```
     #[inline]
     pub fn of<T: Transient>() -> Self {

--- a/src/any.rs
+++ b/src/any.rs
@@ -421,7 +421,7 @@ mod tests {
     use crate::{tr::Transient, Any, Co, Downcast, Inv};
 
     #[cfg(feature = "alloc")]
-    use alloc::boxed::Box;
+    use alloc::{boxed::Box, format};
     // use crate::lib::{format, Box};
 
     #[test]

--- a/src/any.rs
+++ b/src/any.rs
@@ -6,8 +6,8 @@ use crate::{
     transient::Transient,
 };
 
-#[cfg(any(feature = "std", feature = "alloc"))]
-use crate::lib::Box;
+#[cfg(feature = "alloc")]
+use alloc::boxed::Box;
 
 use core::marker::{Send, Sync};
 
@@ -110,7 +110,7 @@ pub trait Downcast<R: Transience> {
     /// Attempt to downcast the box to a concrete type with its lifetime
     /// parameters restored, returning the original in the `Err` variant
     /// if the type was incorrect.
-    #[cfg(any(feature = "std", feature = "alloc"))]
+    #[cfg(feature = "alloc")]
     fn downcast<T: Transient>(self: Box<Self>) -> Result<Box<T>, Box<Self>>
     where
         T::Transience: CanRecoverFrom<R>;
@@ -136,7 +136,7 @@ pub trait Downcast<R: Transience> {
     /// the incorrect type is *undefined behavior*. However, the the caller is _not_
     /// expected to uphold any lifetime guarantees, since the trait bounds handle
     /// this statically.
-    #[cfg(any(feature = "std", feature = "alloc"))]
+    #[cfg(feature = "alloc")]
     unsafe fn downcast_unchecked<T: Transient>(self: Box<Self>) -> Box<T>
     where
         T::Transience: CanRecoverFrom<R>;
@@ -176,7 +176,7 @@ macro_rules! dyn_any_impls {
                 self.type_id() == TypeId::of::<T>()
             }
 
-            #[cfg(any(feature = "std", feature = "alloc"))]
+            #[cfg(feature = "alloc")]
             #[inline]
             fn downcast<T: Transient>(self: Box<Self>) -> Result<Box<T>, Box<Self>>
             where
@@ -216,7 +216,7 @@ macro_rules! dyn_any_impls {
                 }
             }
 
-            #[cfg(any(feature = "std", feature = "alloc"))]
+            #[cfg(feature = "alloc")]
             #[inline]
             unsafe fn downcast_unchecked<T: Transient>(self: Box<Self>) -> Box<T>
             where
@@ -420,11 +420,12 @@ impl core::hash::Hash for TypeId {
 mod tests {
     use crate::{tr::Transient, Any, Co, Downcast, Inv};
 
-    #[cfg(any(feature = "std", feature = "alloc"))]
-    use crate::lib::{format, Box};
+    #[cfg(feature = "alloc")]
+    use alloc::boxed::Box;
+    // use crate::lib::{format, Box};
 
     #[test]
-    #[cfg(any(feature = "std", feature = "alloc"))]
+    #[cfg(feature = "alloc")]
     fn owned_primative_types() {
         let value = 5_usize;
         let valref: &usize = &value;
@@ -560,7 +561,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(any(feature = "std", feature = "alloc"))]
+    #[cfg(feature = "alloc")]
     fn owned_custom_types() {
         let usize_ = Usize(5_usize);
         let usize_ref = UsizeRef(&usize_.0);
@@ -606,7 +607,7 @@ mod tests {
         assert_eq!(inv.downcast_ref::<Usize>().unwrap().0, 5_usize);
         assert_eq!(co.downcast_ref::<Usize>().unwrap().0, 5_usize);
 
-        #[cfg(any(feature = "std", feature = "alloc"))]
+        #[cfg(feature = "alloc")]
         assert_eq!(&format!("{:?}", stc), "dyn Any<()>");
 
         // borrowed `UsizeRef`
@@ -614,7 +615,7 @@ mod tests {
         let co: &dyn Any<Co> = &usize_ref;
         assert_eq!(inv.downcast_ref::<UsizeRef>().unwrap().0, &5_usize);
         assert_eq!(co.downcast_ref::<UsizeRef>().unwrap().0, &5_usize);
-        #[cfg(any(feature = "std", feature = "alloc"))]
+        #[cfg(feature = "alloc")]
         assert_eq!(&format!("{:?}", co), "dyn Any<Co>");
 
         // borrowed `UsizeRef` + Send
@@ -622,7 +623,7 @@ mod tests {
         let co: &(dyn Any<Co> + Send) = &usize_ref;
         assert_eq!(inv.downcast_ref::<UsizeRef>().unwrap().0, &5_usize);
         assert_eq!(co.downcast_ref::<UsizeRef>().unwrap().0, &5_usize);
-        #[cfg(any(feature = "std", feature = "alloc"))]
+        #[cfg(feature = "alloc")]
         assert_eq!(&format!("{:?}", co), "dyn Any<Co> + Send");
 
         // borrowed `UsizeRef` + Send + Sync
@@ -630,7 +631,7 @@ mod tests {
         let co: &(dyn Any<Co> + Send + Sync) = &usize_ref;
         assert_eq!(inv.downcast_ref::<UsizeRef>().unwrap().0, &5_usize);
         assert_eq!(co.downcast_ref::<UsizeRef>().unwrap().0, &5_usize);
-        #[cfg(any(feature = "std", feature = "alloc"))]
+        #[cfg(feature = "alloc")]
         assert_eq!(&format!("{:?}", inv), "dyn Any<Inv> + Send + Sync")
     }
 }

--- a/src/any.rs
+++ b/src/any.rs
@@ -422,7 +422,6 @@ mod tests {
 
     #[cfg(feature = "alloc")]
     use alloc::{boxed::Box, format};
-    // use crate::lib::{format, Box};
 
     #[test]
     #[cfg(feature = "alloc")]

--- a/src/any.rs
+++ b/src/any.rs
@@ -6,10 +6,8 @@ use crate::{
     transient::Transient,
 };
 
-#[cfg(all(feature = "alloc", not(feature = "std")))]
-use alloc::boxed::Box;
-#[cfg(feature = "std")]
-use std::boxed::Box;
+#[cfg(any(feature = "std", feature = "alloc"))]
+use crate::lib::Box;
 
 use core::marker::{Send, Sync};
 
@@ -346,7 +344,6 @@ impl TypeId {
     /// # Examples
     ///
     /// ```
-    ///
     /// # #[cfg(any(feature = "std", feature = "alloc"))] {
     /// use transient::{Transient, Any, TypeId};
     ///
@@ -423,10 +420,8 @@ impl core::hash::Hash for TypeId {
 mod tests {
     use crate::{tr::Transient, Any, Co, Downcast, Inv};
 
-    #[cfg(all(feature = "alloc", not(feature = "std")))]
-    use alloc::{boxed::Box, format};
-    #[cfg(feature = "std")]
-    use std::{boxed::Box, format};
+    #[cfg(any(feature = "std", feature = "alloc"))]
+    use crate::lib::{format, Box};
 
     #[test]
     #[cfg(any(feature = "std", feature = "alloc"))]

--- a/src/any.rs
+++ b/src/any.rs
@@ -346,7 +346,7 @@ impl TypeId {
     /// # Examples
     ///
     /// ```
-    /// 
+    ///
     /// # #[cfg(any(feature = "std", feature = "alloc"))] {
     /// use transient::{Transient, Any, TypeId};
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -361,3 +361,22 @@ pub mod tests;
 #[cfg(all(doctest, feature = "derive"))]
 #[doc = include_str!("../README.md")]
 struct ReadMe;
+
+// A facade around the types we need from the `std` and `alloc` crates to avoid
+// import wrangling having to happen in every module (borrowed from Serde)
+mod lib {
+    mod core {
+        #[cfg(all(feature = "alloc", not(feature = "std")))]
+        pub(crate) use alloc::*;
+        #[cfg(feature = "std")]
+        pub(crate) use std::*;
+    }
+
+    pub(crate) use self::core::{
+        borrow,
+        boxed::Box,
+        collections, format, string,
+        string::{String, ToString},
+        vec::Vec,
+    };
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -370,9 +370,9 @@ struct ReadMe;
 mod lib {
     mod core {
         #[cfg(not(feature = "std"))]
-        pub(crate) use alloc::*;
+        pub(crate) use ::alloc::*;
         #[cfg(feature = "std")]
-        pub(crate) use std::*;
+        pub(crate) use ::std::*;
     }
 
     pub(crate) use self::core::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -362,24 +362,3 @@ pub mod tests;
 #[cfg(all(doctest, feature = "derive"))]
 #[doc = include_str!("../README.md")]
 struct ReadMe;
-
-// A facade around the types we need from the `std` and `alloc` crates to avoid
-// import wrangling having to happen in every module (borrowed from Serde)
-#[cfg(any(feature = "std", feature = "alloc"))]
-#[allow(unused_imports)]
-mod lib {
-    mod core {
-        #[cfg(not(feature = "std"))]
-        pub(crate) use ::alloc::*;
-        #[cfg(feature = "std")]
-        pub(crate) use ::std::*;
-    }
-
-    pub(crate) use self::core::{
-        borrow,
-        boxed::Box,
-        collections, format, string,
-        string::{String, ToString},
-        vec::Vec,
-    };
-}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -307,12 +307,22 @@
 //! [variance]: https://doc.rust-lang.org/nomicon/subtyping.html
 //! [_subtyping and variance_]: https://doc.rust-lang.org/nomicon/subtyping.html
 //! [*the quality or state of being transient*]: https://www.merriam-webster.com/dictionary/transience
+
+////////////////////////////////////////////////////////////////////////////////
+
+// Support using `transient` without the standard library
+#![cfg_attr(not(feature = "std"), no_std)]
 #![deny(missing_docs, clippy::missing_safety_doc)]
 #![allow(
     unknown_lints,
     clippy::too_long_first_doc_paragraph,
     clippy::needless_lifetimes
 )]
+
+////////////////////////////////////////////////////////////////////////////////
+
+#[cfg(feature = "alloc")]
+extern crate alloc;
 
 pub mod any;
 pub mod transience;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,6 +62,7 @@
 //! library once the `Transient` trait has been implemented or derived:
 //! ```
 //! # fn main() {
+//! # #[cfg(feature = "derive")] {
 //! use transient::*;
 //!
 //! #[derive(Transient, Debug, PartialEq)]
@@ -74,7 +75,7 @@
 //!
 //! let restored: &Usize = erased.downcast_ref::<Usize>().unwrap();
 //! assert_eq!(restored, &orig);
-//! # }
+//! # }}
 //! ```
 //! The trick is that the `Any` trait as used above is actually generic over a
 //! type known as the `Transience`, which defaults to `()`; so the relevant line
@@ -98,6 +99,7 @@
 //! `dyn Any<Inv>` when coercing a `Box` or reference to the trait object:
 //! ```
 //! # fn main() {
+//! # #[cfg(feature = "derive")] {
 //! use transient::*;
 //!
 //! #[derive(Transient, Debug, PartialEq)]
@@ -112,7 +114,7 @@
 //!
 //! let restored: &UsizeRef = erased.downcast_ref().unwrap();
 //! assert_eq!(restored, &orig);
-//! # }
+//! # }}
 //! ```
 //!
 //! And that's all it takes! Things get a slightly spicier in more complicated
@@ -356,6 +358,6 @@ pub mod tr {
 #[cfg(test)]
 pub mod tests;
 
-#[cfg(doctest)]
+#[cfg(all(doctest, feature = "derive"))]
 #[doc = include_str!("../README.md")]
 struct ReadMe;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,6 +37,7 @@
 //! - Supports types with any number of generic type parameters
 //! - Provides the [`macro@Transient`] `derive` macro to implement the `Transient`
 //!   trait for most types
+//! - Supports `no_std` environments with or without `alloc`
 //!
 //! # Limitations
 //! - Requires a single `unsafe` trait to be implemented for types wishing to
@@ -364,9 +365,11 @@ struct ReadMe;
 
 // A facade around the types we need from the `std` and `alloc` crates to avoid
 // import wrangling having to happen in every module (borrowed from Serde)
+#[cfg(any(feature = "std", feature = "alloc"))]
+#[allow(unused_imports)]
 mod lib {
     mod core {
-        #[cfg(all(feature = "alloc", not(feature = "std")))]
+        #[cfg(not(feature = "std"))]
         pub(crate) use alloc::*;
         #[cfg(feature = "std")]
         pub(crate) use std::*;

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -3,7 +3,10 @@
 use crate::{tr::Transient, Any, Co, Contra, Inv, TypeId};
 
 #[cfg(feature = "alloc")]
-use alloc::{boxed::Box, string::{String, ToString}};
+use alloc::{
+    boxed::Box,
+    string::{String, ToString},
+};
 
 /// Tests for a covariant struct with no generic type parameters.
 #[cfg(feature = "alloc")]

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,8 +1,23 @@
 //! Tests for various parts of the Transient API
 
+use crate::{tr::Transient, Any, Co, Contra, Inv, TypeId};
+
+#[cfg(all(feature = "alloc", not(feature = "std")))]
+use alloc::{
+    boxed::Box,
+    string::{String, ToString},
+};
+#[cfg(feature = "std")]
+use std::{
+    boxed::Box,
+    string::{String, ToString},
+};
+
 /// Tests for a covariant struct with no generic type parameters.
+#[cfg(any(feature = "std", feature = "alloc"))]
 mod covariant {
-    use crate::{tr::Transient, Any, Co, Downcast, TypeId};
+    use super::*;
+    use crate::Downcast;
 
     #[derive(Debug, Clone, PartialEq, Eq)]
     struct S<'a> {
@@ -48,8 +63,10 @@ mod covariant {
 }
 
 /// Tests for a struct with a generic type parameter
+#[cfg(any(feature = "std", feature = "alloc"))]
 mod one_type_param {
-    use crate::{tr::Transient, Any, Downcast, Inv, TypeId};
+    use super::*;
+    use crate::Downcast;
 
     #[derive(Debug, Clone, PartialEq, Eq)]
     struct S<'a, T> {
@@ -94,7 +111,7 @@ mod one_type_param {
 
 /// Tests for a struct with a two generic type parameters
 mod two_type_params {
-    use crate::{Inv, Transient};
+    use super::*;
 
     #[derive(Debug, Clone, PartialEq, Eq)]
     struct S<'a, T1, T2> {
@@ -109,7 +126,7 @@ mod two_type_params {
 
 /// Tests for a struct with two lifetime params that have different variances
 mod mixed_lifetimes {
-    use crate::{tr::Transient, Any, Co, Contra, TypeId};
+    use super::*;
 
     type ContraCo<'s, 'l> = (Contra<'s>, Co<'l>);
 
@@ -137,6 +154,7 @@ mod mixed_lifetimes {
 
     const STATIC_STR: &str = "static";
 
+    #[cfg(any(feature = "std", feature = "alloc"))]
     #[test]
     #[rustfmt::skip]
     fn test_owned() {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -2,11 +2,11 @@
 
 use crate::{tr::Transient, Any, Co, Contra, Inv, TypeId};
 
-#[cfg(any(feature = "std", feature = "alloc"))]
-use crate::lib::{Box, String, ToString};
+#[cfg(feature = "alloc")]
+use alloc::{boxed::Box, string::{String, ToString}};
 
 /// Tests for a covariant struct with no generic type parameters.
-#[cfg(any(feature = "std", feature = "alloc"))]
+#[cfg(feature = "alloc")]
 mod covariant {
     use super::*;
     use crate::Downcast;

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -2,16 +2,8 @@
 
 use crate::{tr::Transient, Any, Co, Contra, Inv, TypeId};
 
-#[cfg(all(feature = "alloc", not(feature = "std")))]
-use alloc::{
-    boxed::Box,
-    string::{String, ToString},
-};
-#[cfg(feature = "std")]
-use std::{
-    boxed::Box,
-    string::{String, ToString},
-};
+#[cfg(any(feature = "std", feature = "alloc"))]
+use crate::lib::{Box, String, ToString};
 
 /// Tests for a covariant struct with no generic type parameters.
 #[cfg(any(feature = "std", feature = "alloc"))]
@@ -154,8 +146,8 @@ mod mixed_lifetimes {
 
     const STATIC_STR: &str = "static";
 
-    #[cfg(any(feature = "std", feature = "alloc"))]
     #[test]
+    #[cfg(any(feature = "std", feature = "alloc"))]
     #[rustfmt::skip]
     fn test_owned() {
         let short: M<'_, 'static> = M { func: |_| "!", string: STATIC_STR };

--- a/src/transience.rs
+++ b/src/transience.rs
@@ -3,7 +3,7 @@
 //! [`CanRecoverFrom`] traits that establish the allowable transitions between
 //! transiences.
 use crate::tr::Transient;
-use std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Marker trait for types used to establish the [variance] of a type with
 /// respect to each of its lifetime parameters, including [`Co`], [`Contra`],

--- a/src/transient.rs
+++ b/src/transient.rs
@@ -543,12 +543,12 @@ mod std_impls {
     #[cfg(feature = "alloc")]
     mod _alloc {
         use super::{Static, Transient};
-        use alloc::boxed::Box;
-        use alloc::borrow;
-        use alloc::string;
-        use alloc::collections;
-        use alloc::vec::Vec;
         use crate::{Co, Covariant, Inv};
+        use alloc::borrow;
+        use alloc::boxed::Box;
+        use alloc::collections;
+        use alloc::string;
+        use alloc::vec::Vec;
 
         impl_static! {
             Box<str>,

--- a/src/transient.rs
+++ b/src/transient.rs
@@ -459,9 +459,13 @@ mod std_impls {
             ::core::num::TryFromIntError,
             ::core::str::ParseBoolError,
             ::core::str::Utf8Error,
-            ::core::net::AddrParseError,
             ::core::fmt::Error,
         }
+        
+        // the `net` module was not moved from `std` to `core` until Rust 1.77, so the
+        // "std" feature is required on earlier versions (see the `_std` submodule)
+        #[rustversion::since(1.77)]
+        impl_static!(::core::net::AddrParseError);
 
         unsafe impl<'a> Transient for &'a str {
             type Static = &'static str;
@@ -641,6 +645,10 @@ mod std_impls {
             [K: Transient, V: Transient]
             (Covariant<K>, Covariant<V>)
         );
+        
+        // on later Rust versions this impl is available without the "std" feature
+        #[rustversion::before(1.77)]
+        impl_static!(::std::net::AddrParseError);
     }
 }
 

--- a/src/transient.rs
+++ b/src/transient.rs
@@ -461,7 +461,7 @@ mod std_impls {
             ::core::str::Utf8Error,
             ::core::fmt::Error,
         }
-        
+
         // the `net` module was not moved from `std` to `core` until Rust 1.77, so the
         // "std" feature is required on earlier versions (see the `_std` submodule)
         #[rustversion::since(1.77)]
@@ -645,7 +645,7 @@ mod std_impls {
             [K: Transient, V: Transient]
             (Covariant<K>, Covariant<V>)
         );
-        
+
         // on later Rust versions this impl is available without the "std" feature
         #[rustversion::before(1.77)]
         impl_static!(::std::net::AddrParseError);

--- a/src/transient.rs
+++ b/src/transient.rs
@@ -3,10 +3,8 @@
 use crate::any::{Any, TypeId};
 use crate::transience::Transience;
 
-#[cfg(all(feature = "alloc", not(feature = "std")))]
-use alloc::boxed::Box;
-#[cfg(feature = "std")]
-use std::boxed::Box;
+#[cfg(any(feature = "std", feature = "alloc"))]
+use crate::lib::Box;
 
 /// Unsafe trait defining the lifetime-relationships of a potentially non-`'static`
 /// type so that it can be safely erased to [`dyn Any`]. This trait can be safely
@@ -545,16 +543,12 @@ mod std_impls {
     #[cfg(any(feature = "std", feature = "alloc"))]
     mod _alloc {
         use super::{Static, Transient};
+        use crate::lib::{borrow, collections, string, Box, Vec};
         use crate::{Co, Covariant, Inv};
 
-        #[cfg(all(feature = "alloc", not(feature = "std")))]
-        use alloc::{borrow, boxed, collections, string, vec};
-        #[cfg(feature = "std")]
-        use std::{borrow, boxed, collections, string, vec};
-
         impl_static! {
-            boxed::Box<str>,
-            boxed::Box<dyn ::core::any::Any>,
+            Box<str>,
+            Box<dyn ::core::any::Any>,
             string::String,
             string::FromUtf8Error,
             string::FromUtf16Error,
@@ -569,14 +563,14 @@ mod std_impls {
             type Transience = (Co<'a>, Covariant<T>);
         }
 
-        unsafe impl<T: Transient> Transient for vec::Vec<T> {
-            type Static = vec::Vec<T::Static>;
+        unsafe impl<T: Transient> Transient for Vec<T> {
+            type Static = Vec<T::Static>;
             type Transience = Covariant<T>;
         }
-        impl_refs!(vec::Vec<T> [T: Transient] (Covariant<T>));
+        impl_refs!(Vec<T> [T: Transient] (Covariant<T>));
 
-        unsafe impl<T: Transient> Transient for boxed::Box<[T]> {
-            type Static = boxed::Box<[T::Static]>;
+        unsafe impl<T: Transient> Transient for Box<[T]> {
+            type Static = Box<[T::Static]>;
             type Transience = Covariant<T>;
         }
 

--- a/src/transient.rs
+++ b/src/transient.rs
@@ -3,8 +3,8 @@
 use crate::any::{Any, TypeId};
 use crate::transience::Transience;
 
-#[cfg(any(feature = "std", feature = "alloc"))]
-use crate::lib::Box;
+#[cfg(feature = "alloc")]
+use alloc::boxed::Box;
 
 /// Unsafe trait defining the lifetime-relationships of a potentially non-`'static`
 /// type so that it can be safely erased to [`dyn Any`]. This trait can be safely
@@ -540,10 +540,14 @@ mod std_impls {
     }
 
     /// impls that require either the `std` or `alloc` feature
-    #[cfg(any(feature = "std", feature = "alloc"))]
+    #[cfg(feature = "alloc")]
     mod _alloc {
         use super::{Static, Transient};
-        use crate::lib::{borrow, collections, string, Box, Vec};
+        use alloc::boxed::Box;
+        use alloc::borrow;
+        use alloc::string;
+        use alloc::collections;
+        use alloc::vec::Vec;
         use crate::{Co, Covariant, Inv};
 
         impl_static! {


### PR DESCRIPTION
This PR adds support for using the `transient` crate in `no_std` environments, with or without `alloc`, through the addition of new "std" and "alloc" crate features. This PR also includes CI updates that run the tests with various feature sets to ensure everything works regardless of the chosen crate features.

To enable `no_std` mode, disable default features using `--no-default-features` (or `default-features = false` in Cargo.toml). Almost all functionality of the `transient` crate will still be available, except for:
- the `downcast`/`downcast_unchecked` methods on the `dyn Any` trait object (which accepts/returns a `Box`)
- the `Transient::erase` convenience method (which accepts/returns a `Box`)
- `Transient` impls for non-`core` types (particularly `Box`, `Vec`, `String`, and `HashMap`) 

To enable `no_std` mode with `alloc` support, disable default features and enable the "alloc" feature using  `--no-default-features --features alloc` (or `default-features = false, features = ["alloc"]` in Cargo.toml). This restores all of the functionality listed above except for the `Transient` impls for several types that are available in neither `core` nor `alloc`.

Resolves #25
