### PR TITLE
Remove wrangling since `std` types are just re-exports of `core` and `alloc` types whenever possible

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ default = ["std", "derive"]
 
 # Provide impls for common standard library types like Vec<T> and HashMap<K, V>.
 # Requires a dependency on the Rust standard library.
-std = []
+std = ["alloc"]
 
 # Provide impls for types in the Rust core allocation and collections library
 # including String, Box<T>, Vec<T>, and Cow<T>. This is a subset of std but may

--- a/src/any.rs
+++ b/src/any.rs
@@ -421,7 +421,7 @@ mod tests {
     use crate::{tr::Transient, Any, Co, Downcast, Inv};
 
     #[cfg(feature = "alloc")]
-    use alloc::boxed::Box;
+    use alloc::{boxed::Box, format};
     // use crate::lib::{format, Box};
 
     #[test]

--- a/src/any.rs
+++ b/src/any.rs
@@ -6,8 +6,8 @@ use crate::{
     transient::Transient,
 };
 
-#[cfg(any(feature = "std", feature = "alloc"))]
-use crate::lib::Box;
+#[cfg(feature = "alloc")]
+use alloc::boxed::Box;
 
 use core::marker::{Send, Sync};
 
@@ -110,7 +110,7 @@ pub trait Downcast<R: Transience> {
     /// Attempt to downcast the box to a concrete type with its lifetime
     /// parameters restored, returning the original in the `Err` variant
     /// if the type was incorrect.
-    #[cfg(any(feature = "std", feature = "alloc"))]
+    #[cfg(feature = "alloc")]
     fn downcast<T: Transient>(self: Box<Self>) -> Result<Box<T>, Box<Self>>
     where
         T::Transience: CanRecoverFrom<R>;
@@ -136,7 +136,7 @@ pub trait Downcast<R: Transience> {
     /// the incorrect type is *undefined behavior*. However, the the caller is _not_
     /// expected to uphold any lifetime guarantees, since the trait bounds handle
     /// this statically.
-    #[cfg(any(feature = "std", feature = "alloc"))]
+    #[cfg(feature = "alloc")]
     unsafe fn downcast_unchecked<T: Transient>(self: Box<Self>) -> Box<T>
     where
         T::Transience: CanRecoverFrom<R>;
@@ -176,7 +176,7 @@ macro_rules! dyn_any_impls {
                 self.type_id() == TypeId::of::<T>()
             }
 
-            #[cfg(any(feature = "std", feature = "alloc"))]
+            #[cfg(feature = "alloc")]
             #[inline]
             fn downcast<T: Transient>(self: Box<Self>) -> Result<Box<T>, Box<Self>>
             where
@@ -216,7 +216,7 @@ macro_rules! dyn_any_impls {
                 }
             }
 
-            #[cfg(any(feature = "std", feature = "alloc"))]
+            #[cfg(feature = "alloc")]
             #[inline]
             unsafe fn downcast_unchecked<T: Transient>(self: Box<Self>) -> Box<T>
             where
@@ -420,11 +420,12 @@ impl core::hash::Hash for TypeId {
 mod tests {
     use crate::{tr::Transient, Any, Co, Downcast, Inv};
 
-    #[cfg(any(feature = "std", feature = "alloc"))]
-    use crate::lib::{format, Box};
+    #[cfg(feature = "alloc")]
+    use alloc::boxed::Box;
+    // use crate::lib::{format, Box};
 
     #[test]
-    #[cfg(any(feature = "std", feature = "alloc"))]
+    #[cfg(feature = "alloc")]
     fn owned_primative_types() {
         let value = 5_usize;
         let valref: &usize = &value;
@@ -560,7 +561,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(any(feature = "std", feature = "alloc"))]
+    #[cfg(feature = "alloc")]
     fn owned_custom_types() {
         let usize_ = Usize(5_usize);
         let usize_ref = UsizeRef(&usize_.0);
@@ -606,7 +607,7 @@ mod tests {
         assert_eq!(inv.downcast_ref::<Usize>().unwrap().0, 5_usize);
         assert_eq!(co.downcast_ref::<Usize>().unwrap().0, 5_usize);
 
-        #[cfg(any(feature = "std", feature = "alloc"))]
+        #[cfg(feature = "alloc")]
         assert_eq!(&format!("{:?}", stc), "dyn Any<()>");
 
         // borrowed `UsizeRef`
@@ -614,7 +615,7 @@ mod tests {
         let co: &dyn Any<Co> = &usize_ref;
         assert_eq!(inv.downcast_ref::<UsizeRef>().unwrap().0, &5_usize);
         assert_eq!(co.downcast_ref::<UsizeRef>().unwrap().0, &5_usize);
-        #[cfg(any(feature = "std", feature = "alloc"))]
+        #[cfg(feature = "alloc")]
         assert_eq!(&format!("{:?}", co), "dyn Any<Co>");
 
         // borrowed `UsizeRef` + Send
@@ -622,7 +623,7 @@ mod tests {
         let co: &(dyn Any<Co> + Send) = &usize_ref;
         assert_eq!(inv.downcast_ref::<UsizeRef>().unwrap().0, &5_usize);
         assert_eq!(co.downcast_ref::<UsizeRef>().unwrap().0, &5_usize);
-        #[cfg(any(feature = "std", feature = "alloc"))]
+        #[cfg(feature = "alloc")]
         assert_eq!(&format!("{:?}", co), "dyn Any<Co> + Send");
 
         // borrowed `UsizeRef` + Send + Sync
@@ -630,7 +631,7 @@ mod tests {
         let co: &(dyn Any<Co> + Send + Sync) = &usize_ref;
         assert_eq!(inv.downcast_ref::<UsizeRef>().unwrap().0, &5_usize);
         assert_eq!(co.downcast_ref::<UsizeRef>().unwrap().0, &5_usize);
-        #[cfg(any(feature = "std", feature = "alloc"))]
+        #[cfg(feature = "alloc")]
         assert_eq!(&format!("{:?}", inv), "dyn Any<Inv> + Send + Sync")
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -362,24 +362,3 @@ pub mod tests;
 #[cfg(all(doctest, feature = "derive"))]
 #[doc = include_str!("../README.md")]
 struct ReadMe;
-
-// A facade around the types we need from the `std` and `alloc` crates to avoid
-// import wrangling having to happen in every module (borrowed from Serde)
-#[cfg(any(feature = "std", feature = "alloc"))]
-#[allow(unused_imports)]
-mod lib {
-    mod core {
-        #[cfg(not(feature = "std"))]
-        pub(crate) use ::alloc::*;
-        #[cfg(feature = "std")]
-        pub(crate) use ::std::*;
-    }
-
-    pub(crate) use self::core::{
-        borrow,
-        boxed::Box,
-        collections, format, string,
-        string::{String, ToString},
-        vec::Vec,
-    };
-}

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -3,7 +3,10 @@
 use crate::{tr::Transient, Any, Co, Contra, Inv, TypeId};
 
 #[cfg(feature = "alloc")]
-use alloc::{boxed::Box, string::{String, ToString}};
+use alloc::{
+    boxed::Box,
+    string::{String, ToString},
+};
 
 /// Tests for a covariant struct with no generic type parameters.
 #[cfg(feature = "alloc")]

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -2,11 +2,11 @@
 
 use crate::{tr::Transient, Any, Co, Contra, Inv, TypeId};
 
-#[cfg(any(feature = "std", feature = "alloc"))]
-use crate::lib::{Box, String, ToString};
+#[cfg(feature = "alloc")]
+use alloc::{boxed::Box, string::{String, ToString}};
 
 /// Tests for a covariant struct with no generic type parameters.
-#[cfg(any(feature = "std", feature = "alloc"))]
+#[cfg(feature = "alloc")]
 mod covariant {
     use super::*;
     use crate::Downcast;

--- a/src/transient.rs
+++ b/src/transient.rs
@@ -543,12 +543,12 @@ mod std_impls {
     #[cfg(feature = "alloc")]
     mod _alloc {
         use super::{Static, Transient};
-        use alloc::boxed::Box;
-        use alloc::borrow;
-        use alloc::string;
-        use alloc::collections;
-        use alloc::vec::Vec;
         use crate::{Co, Covariant, Inv};
+        use alloc::borrow;
+        use alloc::boxed::Box;
+        use alloc::collections;
+        use alloc::string;
+        use alloc::vec::Vec;
 
         impl_static! {
             Box<str>,

--- a/src/transient.rs
+++ b/src/transient.rs
@@ -3,8 +3,8 @@
 use crate::any::{Any, TypeId};
 use crate::transience::Transience;
 
-#[cfg(any(feature = "std", feature = "alloc"))]
-use crate::lib::Box;
+#[cfg(feature = "alloc")]
+use alloc::boxed::Box;
 
 /// Unsafe trait defining the lifetime-relationships of a potentially non-`'static`
 /// type so that it can be safely erased to [`dyn Any`]. This trait can be safely
@@ -540,10 +540,14 @@ mod std_impls {
     }
 
     /// impls that require either the `std` or `alloc` feature
-    #[cfg(any(feature = "std", feature = "alloc"))]
+    #[cfg(feature = "alloc")]
     mod _alloc {
         use super::{Static, Transient};
-        use crate::lib::{borrow, collections, string, Box, Vec};
+        use alloc::boxed::Box;
+        use alloc::borrow;
+        use alloc::string;
+        use alloc::collections;
+        use alloc::vec::Vec;
         use crate::{Co, Covariant, Inv};
 
         impl_static! {


### PR DESCRIPTION
This also makes the `std` feature dependent on `alloc`.

I'm pretty sure serde has the import wrangling section simply so they can `use crate::lib::*;` in both the serialize and deserialize modules. My understanding is that import wrangling should never be needed.

Every `std` type with a corresponding `core` or `alloc` type is (to the best of my knowledge) actually just a re-export of the `core` or `alloc` type. For crates that don't need `alloc` or `std` only types, they can just declare `#![no_std]` unconditionally, and still work just fine with std crates.

